### PR TITLE
Restart feature for processors

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
@@ -645,7 +645,7 @@
          *
          * @argument {selection} selection      The selection
          */
-        start: function (selection) {
+        start: function (selection, cb) {
             if (selection.empty()) {
                 // build the entity
                 var entity = {
@@ -696,7 +696,13 @@
                     if (startRequests.length > 0) {
                         $.when.apply(window, startRequests).always(function () {
                             nfNgBridge.digest();
+
+                            if(typeof cb == 'function'){
+                                cb();
+                            }
                         });
+                    } else if(typeof cb == 'function'){
+                        cb();
                     }
                 }
             }
@@ -811,6 +817,35 @@
         },
 
         /**
+         * Restart the processor
+         *
+         * @param {selection}       selection
+         * @param {cb} callback     The function to call when complete
+         */
+        restart: function (selection,cb) {
+          if(selection.size() === 1 &&
+                nfCanvasUtils.isProcessor(selection) &&
+                nfCanvasUtils.canModify(selection)){
+
+                nfActions.stop(selection,function(){
+                  nfActions.terminate(selection, function(){
+                    var selectionData = selection.datum();                   
+                    if(selectionData.status.aggregateSnapshot.activeThreadCount > 0){
+                        nfDialog.showOkDialog({
+                            dialogContent: 'Unable to restart, active threads could not be terminated.',
+                            headerText: 'Unable to Restart'
+                        });
+                    }
+                    else{
+                        nfActions.start(selection, cb);        
+                    }      
+                    
+                  });     
+
+                });
+            }
+        },
+        /**
          * Enables transmission for the components in the specified selection.
          *
          * @argument {selection} selection      The selection
@@ -885,7 +920,16 @@
                 }
             }
         },
-
+        /**
+         * Hides the configuration dialog for the specified selection. 
+         *
+         *  @param {selection} selection     Selection of the component to be configured
+         */
+        hideConfiguration: function (selection) {
+            if (nfCanvasUtils.isProcessor(selection)) {                
+                nfProcessorConfiguration.hideConfiguration(selection);
+            }
+        },
         /**
          * Opens the policy management page for the selected component.
          *

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-actions.js
@@ -697,11 +697,11 @@
                         $.when.apply(window, startRequests).always(function () {
                             nfNgBridge.digest();
 
-                            if(typeof cb == 'function'){
+                            if (typeof cb == 'function') {
                                 cb();
                             }
                         });
-                    } else if(typeof cb == 'function'){
+                    } else if (typeof cb == 'function') {
                         cb();
                     }
                 }
@@ -823,20 +823,20 @@
          * @param {cb} callback     The function to call when complete
          */
         restart: function (selection,cb) {
-          if(selection.size() === 1 &&
+          if (selection.size() === 1 &&
                 nfCanvasUtils.isProcessor(selection) &&
-                nfCanvasUtils.canModify(selection)){
+                nfCanvasUtils.canModify(selection)) {
 
-                nfActions.stop(selection,function(){
-                  nfActions.terminate(selection, function(){
+                nfActions.stop(selection,function() {
+                  nfActions.terminate(selection, function() {
                     var selectionData = selection.datum();                   
-                    if(selectionData.status.aggregateSnapshot.activeThreadCount > 0){
+                    if (selectionData.status.aggregateSnapshot.activeThreadCount > 0) {
                         nfDialog.showOkDialog({
                             dialogContent: 'Unable to restart, active threads could not be terminated.',
                             headerText: 'Unable to Restart'
                         });
                     }
-                    else{
+                    else {
                         nfActions.start(selection, cb);        
                     }      
                     

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
@@ -178,7 +178,7 @@
          *
          * @param type  The type of component.
          */
-        getComponentByType: function (type) {
+        getComponentByType: function (type) {           
             return nfGraph.getComponentByType(type);
         },
 
@@ -826,8 +826,7 @@
          * @param {function} setOffset          Optional function to handle the width of the active thread count component
          * @return
          */
-        activeThreadCount: function (selection, d, setOffset) {
-            var activeThreads = d.status.aggregateSnapshot.activeThreadCount;
+        activeThreadCount: function (selection, d, setOffset) {            var activeThreads = d.status.aggregateSnapshot.activeThreadCount;
             var terminatedThreads = d.status.aggregateSnapshot.terminatedThreadCount;
 
             // if there is active threads show the count, otherwise hide

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
@@ -826,7 +826,8 @@
          * @param {function} setOffset          Optional function to handle the width of the active thread count component
          * @return
          */
-        activeThreadCount: function (selection, d, setOffset) {            var activeThreads = d.status.aggregateSnapshot.activeThreadCount;
+        activeThreadCount: function (selection, d, setOffset) {            v
+        	var activeThreads = d.status.aggregateSnapshot.activeThreadCount;
             var terminatedThreads = d.status.aggregateSnapshot.terminatedThreadCount;
 
             // if there is active threads show the count, otherwise hide

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-canvas-utils.js
@@ -826,7 +826,7 @@
          * @param {function} setOffset          Optional function to handle the width of the active thread count component
          * @return
          */
-        activeThreadCount: function (selection, d, setOffset) {            v
+        activeThreadCount: function (selection, d, setOffset) {            
         	var activeThreads = d.status.aggregateSnapshot.activeThreadCount;
             var terminatedThreads = d.status.aggregateSnapshot.terminatedThreadCount;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
@@ -773,7 +773,6 @@
     var executeAction = function (action, selection, evt) {
         // execute the action
         nfActions[action](selection, evt);
-
         // close the context menu
         nfContextMenu.hide();
     };
@@ -805,6 +804,7 @@
         {id: 'start-menu-item', condition: isRunnable, menuItem: {clazz: 'fa fa-play', text: 'Start', action: 'start'}},
         {id: 'stop-menu-item', condition: isStoppable, menuItem: {clazz: 'fa fa-stop', text: 'Stop', action: 'stop'}},
         {id: 'terminate-menu-item', condition: canTerminate, menuItem: {clazz: 'fa fa-hourglass-end', text: 'Terminate', action: 'terminate'}},
+        {id: 'restart-menu-item', condition: isStoppable, menuItem: {clazz: 'fa fa-repeat', text: 'Restart', action: 'restart'}},
         {id: 'enable-menu-item', condition: canEnable, menuItem: {clazz: 'fa fa-flash', text: 'Enable', action: 'enable'}},
         {id: 'disable-menu-item', condition: canDisable, menuItem: {clazz: 'icon icon-enable-false', text: 'Disable', action: 'disable'}},
         {id: 'enable-transmission-menu-item', condition: canStartTransmission, menuItem: {clazz: 'fa fa-bullseye', text: 'Enable transmission', action: 'enableTransmission'}},

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -666,7 +666,13 @@
                 }
             });
         },
-
+        /**
+         * Hides the configuration dialog 
+         *
+         */
+        hideConfiguration: function () {
+            $('#processor-configuration').modal('hide');
+        },
         /**
          * Shows the configuration dialog for the specified processor.
          *
@@ -929,11 +935,13 @@
                             $('#processor-configuration').modal('refreshButtons');
                         });
 
+
+                        var processorBtns = [];
                         //if there are active threads, add the terminate button to the status bar
                         if(nfCommon.isDefinedAndNotNull(config.nfActions) &&
                             nfCommon.getKeyValue(processorResponse,ACTIVE_THREAD_COUNT_KEY) != 0){
-
-                            $("#processor-configuration-status-bar").statusbar('buttons',[{
+                            
+                            processorBtns.push({
                                 buttonText: 'Terminate',
                                 clazz: 'fa fa-hourglass-end button-icon',
                                 color: {
@@ -957,7 +965,7 @@
                                             else {
                                                 //refresh the dialog
                                                 $('#processor-configuration-status-bar').statusbar('refreshButtons');
-                                                $('#processor-configuration').modal('refreshButtons');
+                                                $('#processor-configuration').modal('refreshButtons');;
                                             }
                                             $('#processor-configuration-status-bar').statusbar('showButtons');
                                         };
@@ -967,11 +975,38 @@
                                         config.nfActions.terminate(selection,cb);
                                     }
                                 }
-                            }]);
+                            });
                         }
+                        // Add start button to the statusbar
+                        if(nfCommon.isDefinedAndNotNull(config.nfActions))
+                        {                            
+                            processorBtns.push({
+                                buttonText: 'Start',
+                                clazz: 'fa fa-play button-icon',
+                                color: {
+                                    hover: '#C7D2D7',
+                                    base: 'transparent',
+                                    text: '#004849'
+                                },
+                                disabled : function() {
+                                    return !nfCanvasUtils.isRunnable(selection);
+                                },
+                                handler: {
+                                    click: function() {
+                                      $("#processor-configuration-status-bar").statusbar('hideButtons');
+                                      config.nfActions.start(selection, function(){
+                                        config.nfActions.showDetails(selection);    
+                                      });                                      
+                                    }
+                                }
+                            });
+                        }
+                        $("#processor-configuration-status-bar").statusbar('buttons',processorBtns);                       
                     }
                     // set the button model
                     $('#processor-configuration').modal('setButtonModel', buttons);
+                    $('#processor-configuration').modal('show');
+                    $("#processor-configuration-status-bar").statusbar('showButtons');
 
                     // load the property table
                     $('#processor-properties')

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-processor-configuration.js
@@ -978,8 +978,7 @@
                             });
                         }
                         // Add start button to the statusbar
-                        if(nfCommon.isDefinedAndNotNull(config.nfActions))
-                        {                            
+                        if (nfCommon.isDefinedAndNotNull(config.nfActions)) {                            
                             processorBtns.push({
                                 buttonText: 'Start',
                                 clazz: 'fa fa-play button-icon',
@@ -994,7 +993,7 @@
                                 handler: {
                                     click: function() {
                                       $("#processor-configuration-status-bar").statusbar('hideButtons');
-                                      config.nfActions.start(selection, function(){
+                                      config.nfActions.start(selection, function() {
                                         config.nfActions.showDetails(selection);    
                                       });                                      
                                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-processor-details.js
@@ -302,6 +302,7 @@
                         click: function () {
                             // hide the dialog
                             $('#processor-details').modal('hide');
+                            config.nfActions.hideConfiguration(selection);
                         }
                     }
                 }];
@@ -351,6 +352,26 @@
                         };
 
                         $("#processor-details-status-bar").statusbar('buttons',[{
+                            buttonHtml: '<i class="fa fa-repeat" aria-hidden="true"></i><span>Restart</span>',
+                            clazz: 'button button-icon auto-width',
+                            color: {
+                                hover: '#C7D2D7',
+                                base: 'transparent',
+                                text: '#004849'
+                            },
+                            disabled : function() {
+                                return !config.nfCanvasUtils.isStoppable(selection);
+                            },
+                            handler: {
+                                click: function() {
+                                    $("#processor-details-status-bar").statusbar('hideButtons');
+                                    config.nfActions.restart(selection,function(){
+                                      $("#processor-details-status-bar").statusbar('showButtons');
+                                    });
+                                }
+                            }
+                        },
+                        {
                             buttonHtml: '<i class="fa fa-stop stop-configure-icon" aria-hidden="true"></i><span>Stop & Configure</span>',
                             clazz: 'button button-icon auto-width',
                             color: {
@@ -368,7 +389,7 @@
                                     config.nfActions.stopAndConfigure(selection,cb);
                                 }
                             }
-                        },
+                        },                      
                         {
                             buttonText: 'Configure',
                             clazz: 'fa fa-cog button-icon',


### PR DESCRIPTION
Adds the ability to restart a processor immediately instead of doing stop, terminate, and start. It also adds the ability to start a processor when viewing the configurations.  “Stop & Configure” is already there, but not a “Start” button.

UI Changes are: 1) The context menu for the processor will show a restart option if the processer is running. 2) The Processor configuration dialog will have a restart button along with the Stop & Configure button, and also a new Start button will show if the processor is not currently running.