### PR TITLE
Fix saving and loading of valid flow.xml.gz

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -447,8 +447,10 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
         this.configuredForClustering = configuredForClustering;
         this.flowRegistryClient = flowRegistryClient;
 
-        timerDrivenEngineRef = new AtomicReference<>(new FlowEngine(maxTimerDrivenThreads.get(), "Timer-Driven Process"));
-        eventDrivenEngineRef = new AtomicReference<>(new FlowEngine(maxEventDrivenThreads.get(), "Event-Driven Process"));
+        // Have data tasks run at a lower priority to yield to NiFi's core including 
+        // cluster synchronization and coordination
+        timerDrivenEngineRef = new AtomicReference<>(new FlowEngine(maxTimerDrivenThreads.get(), "Timer-Driven Process", 3));
+        eventDrivenEngineRef = new AtomicReference<>(new FlowEngine(maxEventDrivenThreads.get(), "Event-Driven Process", 3));
 
         final FlowFileRepository flowFileRepo = createFlowFileRepository(nifiProperties, extensionManager, resourceClaimManager);
         flowFileRepository = flowFileRepo;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -16,6 +16,34 @@
  */
 package org.apache.nifi.controller;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.authorization.AuthorizerCapabilityDetection;
@@ -68,43 +96,10 @@ import org.apache.nifi.reporting.EventAccess;
 import org.apache.nifi.services.FlowService;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
-import org.apache.nifi.util.file.FileUtils;
 import org.apache.nifi.web.api.dto.TemplateDTO;
 import org.apache.nifi.web.revision.RevisionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 public class StandardFlowService implements FlowService, ProtocolHandler {
 
@@ -260,9 +255,8 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
     @Override
     public void overwriteFlow(final InputStream is) throws IOException {
         writeLock.lock();
-        try (final OutputStream output = Files.newOutputStream(flowXml, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
-                final OutputStream gzipOut = new GZIPOutputStream(output)) {
-            FileUtils.copy(is, gzipOut);
+        try {
+            dao.save(is);
         } finally {
             writeLock.unlock();
         }
@@ -463,25 +457,31 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
     @Override
     public void load(final DataFlow dataFlow) throws IOException, FlowSerializationException, FlowSynchronizationException, UninheritableFlowException, MissingBundleException {
         if (configuredForClustering) {
-            // Create the initial flow from disk if it exists, or from serializing the empty root group in flow controller
-            final DataFlow initialFlow = (dataFlow == null) ? createDataFlow() : dataFlow;
-            if (logger.isTraceEnabled()) {
-                logger.trace("InitialFlow = " + new String(initialFlow.getFlow(), StandardCharsets.UTF_8));
-            }
-
-            // Sync the initial flow into the flow controller so that if the flow came from disk we loaded the
-            // whole flow into the flow controller and applied any bundle upgrades
-            writeLock.lock();
-            try {
-                loadFromBytes(initialFlow, true);
-            } finally {
-                writeLock.unlock();
-            }
-
             // Get the proposed flow by serializing the flow controller which now has the synced version from above
-            final DataFlow proposedFlow = createDataFlowFromController();
-            if (logger.isTraceEnabled()) {
-                logger.trace("ProposedFlow = " + new String(proposedFlow.getFlow(), StandardCharsets.UTF_8));
+            DataFlow proposedFlow = null;
+            try {
+                // Create the initial flow from disk if it exists, or from serializing the empty root group in flow controller
+                final DataFlow initialFlow = (dataFlow == null) ? createDataFlow() : dataFlow;
+                if (logger.isTraceEnabled()) {
+                    logger.trace("InitialFlow = " + new String(initialFlow.getFlow(), StandardCharsets.UTF_8));
+                }
+
+                // Sync the initial flow into the flow controller so that if the flow came from disk we loaded the
+                // whole flow into the flow controller and applied any bundle upgrades
+                writeLock.lock();
+                try {
+                    loadFromBytes(initialFlow, true);
+                } finally {
+                    writeLock.unlock();
+                }
+
+                proposedFlow = createDataFlowFromController();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("ProposedFlow = " + new String(proposedFlow.getFlow(), StandardCharsets.UTF_8));
+                }
+            } catch (IOException | FlowSerializationException e) {
+                // For IO failures, we cannot load the local flow from file or FlowController,
+                // but we ignore them here to allow connection to cluster and pulling the flow from it
             }
 
             /*
@@ -607,11 +607,15 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             dao.load(baos);
             final byte[] bytes = baos.toByteArray();
-
-            final byte[] snippetBytes = controller.getSnippetManager().export();
-            final byte[] authorizerFingerprint = getAuthorizerFingerprint();
-            final StandardDataFlow fromDisk = new StandardDataFlow(bytes, snippetBytes, authorizerFingerprint, new HashSet<>());
-            return fromDisk;
+            
+            if (dao.isValidXml(bytes)) {
+                final byte[] snippetBytes = controller.getSnippetManager().export();
+                final byte[] authorizerFingerprint = getAuthorizerFingerprint();
+                final StandardDataFlow fromDisk = new StandardDataFlow(bytes, snippetBytes, authorizerFingerprint, new HashSet<>());
+                return fromDisk;
+            } else {
+                logger.warn("Existing DataFlow is not a valid XML. Trying to obtain it from FlowController...");
+            }
         }
 
         // Flow from disk does not exist, so serialize the Flow Controller and use that.
@@ -621,7 +625,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
         // end up with the same ID for the root Process Group.
         return createDataFlowFromController();
     }
-
+    
     @Override
     public StandardDataFlow createDataFlowFromController() throws IOException {
         final byte[] snippetBytes = controller.getSnippetManager().export();
@@ -669,6 +673,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
 
             clusterCoordinator.resetNodeStatuses(connectionResponse.getNodeConnectionStatuses().stream()
                     .collect(Collectors.toMap(NodeConnectionStatus::getNodeIdentifier, status -> status)));
+        
             // reconnected, this node needs to explicitly write the inherited flow to disk, and resume heartbeats
             saveFlowChanges();
             controller.resumeHeartbeats();
@@ -1051,14 +1056,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
     public void copyCurrentFlow(final OutputStream os) throws IOException {
         readLock.lock();
         try {
-            if (!Files.exists(flowXml) || Files.size(flowXml) == 0) {
-                return;
-            }
-
-            try (final InputStream in = Files.newInputStream(flowXml, StandardOpenOption.READ);
-                    final InputStream gzipIn = new GZIPInputStream(in)) {
-                FileUtils.copy(gzipIn, os);
-            }
+            dao.load(os);
         } finally {
             readLock.unlock();
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -614,7 +614,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
                 final StandardDataFlow fromDisk = new StandardDataFlow(bytes, snippetBytes, authorizerFingerprint, new HashSet<>());
                 return fromDisk;
             } else {
-                logger.warn("Existing DataFlow is not a valid XML. Trying to obtain it from FlowController...");
+                logger.warn("Existing Flow XML is malformed. Trying to obtain it from FlowController...");
             }
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/engine/FlowEngine.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/engine/FlowEngine.java
@@ -43,7 +43,17 @@ public final class FlowEngine extends ScheduledThreadPoolExecutor {
     public FlowEngine(int corePoolSize, final String threadNamePrefix) {
         this(corePoolSize, threadNamePrefix, false);
     }
-
+    
+    /**
+     * Creates a new instance of FlowEngine
+     * @param corePoolSize the maximum number of threads available to tasks running in the engine.
+     * @param threadNamePrefix for naming the thread
+     * @param threadPriority The priority of the thread
+     */
+    public FlowEngine(int corePoolSize, final String threadNamePrefix, final int threadPriority) {
+        this(corePoolSize, threadNamePrefix, false, threadPriority);
+    }
+    
     /**
      * Creates a new instance of FlowEngine
      *
@@ -52,6 +62,18 @@ public final class FlowEngine extends ScheduledThreadPoolExecutor {
      * @param daemon if true, the thread pool will be populated with daemon threads, otherwise the threads will not be marked as daemon.
      */
     public FlowEngine(int corePoolSize, final String threadNamePrefix, final boolean daemon) {
+        this(corePoolSize, threadNamePrefix, daemon, Thread.NORM_PRIORITY);
+    }
+
+    /**
+     * Creates a new instance of FlowEngine
+     *
+     * @param corePoolSize the maximum number of threads available to tasks running in the engine.
+     * @param threadNamePrefix for thread naming
+     * @param daemon if true, the thread pool will be populated with daemon threads, otherwise the threads will not be marked as daemon.
+     * @param threadPriority The priority of the thread
+     */
+    public FlowEngine(int corePoolSize, final String threadNamePrefix, final boolean daemon, final int threadPriority) {
         super(corePoolSize);
 
         final AtomicInteger threadIndex = new AtomicInteger(0);
@@ -62,6 +84,7 @@ public final class FlowEngine extends ScheduledThreadPoolExecutor {
                 final Thread t = defaultThreadFactory.newThread(r);
                 if (daemon) {
                     t.setDaemon(true);
+                    t.setPriority(threadPriority);
                 }
                 t.setName(threadNamePrefix + " Thread-" + threadIndex.incrementAndGet());
                 return t;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/FlowConfigurationDAO.java
@@ -19,6 +19,9 @@ package org.apache.nifi.persistence;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.nifi.cluster.protocol.DataFlow;
 import org.apache.nifi.controller.FlowController;
@@ -26,6 +29,7 @@ import org.apache.nifi.controller.MissingBundleException;
 import org.apache.nifi.controller.UninheritableFlowException;
 import org.apache.nifi.controller.serialization.FlowSerializationException;
 import org.apache.nifi.controller.serialization.FlowSynchronizationException;
+import org.xml.sax.InputSource;
 
 /**
  * Interface to define service methods for FlowController configuration.
@@ -111,5 +115,19 @@ public interface FlowConfigurationDAO {
      * @throws IllegalStateException if FileFlowDAO not in proper state for saving
      */
     void save(FlowController flow, boolean archive) throws IOException;
+    
+    default boolean isValidXml(byte[] flowXml) {
+        boolean valid = true;
+        if (flowXml == null || flowXml.length == 0) {
+            return false;
+        }
+        try {
+            DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(
+                    new InputSource(new StringReader(new String(flowXml))));
+        } catch (Exception e) {
+            valid = false;
+        }
+        return valid;
+    }
 
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/StandardXMLFlowConfigurationDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/persistence/StandardXMLFlowConfigurationDAO.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.persistence;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -117,12 +118,13 @@ public final class StandardXMLFlowConfigurationDAO implements FlowConfigurationD
         }
 
         try (final InputStream inStream = Files.newInputStream(flowXmlPath, StandardOpenOption.READ);
-                final InputStream gzipIn = new GZIPInputStream(inStream);
-                final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            // Make sure flow XML is not malformed before writing it out
+                final InputStream gzipIn = new GZIPInputStream(inStream)) {
+            // Make sure flow XML is well-formed before writing it out
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             FileUtils.copy(gzipIn, baos);
             if (isValidXml(baos.toByteArray())) {
-                FileUtils.copy(gzipIn, os);
+                ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+                FileUtils.copy(bais, os);
             }
         } catch (IOException e) {
             // Just ignore the corrupt file. Cluster/FlowController synchronization will


### PR DESCRIPTION
Add validation of flow.xml.gz in saving and loading it to ensure the file's integrity and allow cluster synchronization to proceed on and NiFi to start despite IOException.
